### PR TITLE
Alter GAMBITcore to skip core-genome assessment if GAMBIT call is higher than Species level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,11 +162,15 @@ cython_debug/
 # Testing directory
 output_dir
 output_databases
+
 # notes
 method
 correct_incorrect_predictions.txt
 results.csv
 output_logfile.txt
 
+# data
+*.fasta
+*.json
 *.gz
 *.gdb

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GAMBITcore
 This application takes in assemblies, identifies the species, then calculates the completeness of the assemblies against the species core genome.  This is 
 a good quality control step. It is acheived by looking at the GAMBIT k-mers in the assembly and comparing them to the GAMBIT k-mers in the core genome. If the assembly is poor quality, it is expected that the completeness 
-of the assembly will be lower.  
+of the assembly will be lower.  If GAMBIT cannot make a species or subspecies level call, GAMBITcore will be skipped.
 
 ## Installation
 If you want to quickly try out the software, please use the docker container.
@@ -74,6 +74,7 @@ __verbose__: Turn on verbose output. This is set to False by default. This will 
 
 ### Output
 gambitcore will then output a tab delimited output to standard out that looks like this:
+
 | Filename                            | Species                       | Completeness (%) | Assembly core/Species Core | Closest accession   | Closest distance | Assembly k-mers| Species k-mers Mean | Species k-mers Std Dev | Assembly QC |
 |-------------------------------------|-------------------------------|------------------|----------------------------|---------------------|------------------|----------------|---------------------|------------------------|-------------|
 | test/fasta/GCF_002800775.1.fna.gz   | Mycobacteroides abscessus     | 100.00%          | (5296/5296)                | GCF_000758385.1     | 0.0360           | 10847          | 10635               | 403                    | green       |
@@ -103,6 +104,11 @@ __Species k-mers mean__: The mean GAMBIT k-mers for the species (all GAMBIT k-me
 __Species k-mers std dev__: The standard deviation of the number of GABMIT k-mers in a sample. 
 
 __Assembly QC__: This is a colour coded output to give you an indication of the quality of the assembly. Green means the Assembly k-mers are within 2 standard deviations (95%) of the species k-mers mean.  Amber means the Assembly k-mers are between 2 and 3 standard deviations (99.7%) of the species k-mers mean. Red means the Assembly k-mers are more than 3 standard deviations of the species k-mers mean and something might be very wrong. This is a very rough guide, but it can be useful to quickly identify assemblies that are an unusual size relative to the species.
+
+> :warning: Warning
+> 
+> If GAMBIT failes to make a species- or subspecies-level assignment, GAMBITcore will be skipped with the message "Species could not be identified, skipping core genome assessment". 
+
 
 ## gambitcore-species
 This is a script which takes in a GAMBIT database and calculates the core k-mers for every species in the database. It then outputs the details for each species to a tab delimited file.

--- a/scripts/gambitcore
+++ b/scripts/gambitcore
@@ -49,39 +49,47 @@ def run_gambit_core_check(gambit_directory, fasta_filename, cpus):
     closest_distance = None
     with tempfile.TemporaryDirectory() as temp_dir:
         gambit_output = os.path.join(temp_dir, 'gambit_output.json')
-        os.system(f"gambit -d {gambit_directory} query --no-progress -o {gambit_output} -c {cpus} -f archive {fasta_filename}")
+        os.system(f"gambit -d {gambit_directory} query --no-progress -o {gambit_output} -c {cpus} -f json {fasta_filename}")
 
         with open(gambit_output, 'r') as f:
             data = json.load(f)
-            closest_genomes_json = data['items'][0]['classifier_result']['closest_match']
+            rank = data['items'][0]['predicted_taxon']['rank']
+            closest_genomes_json = data['items'][0]['closest_genomes'][0]
             closest_accession = closest_genomes_json['genome']['key']
             closest_distance = closest_genomes_json['distance']
 
     logging.info(f"Filename: {fasta_filename}")
     logging.info(f"Closest accession: {closest_accession}")
     logging.info(f"Closest distance: {closest_distance}")
-
-    return closest_accession, closest_distance
+    logging.info(f"Rank: {rank}")
+    return closest_accession, closest_distance, rank
 
 def intersection_kmers(core_kmers, genome_kmers):
     return np.intersect1d(core_kmers, genome_kmers)
 
 def construct_extended_output(interection_of_kmers, core_kmers, closest_accession, closest_distance, fasta_filename, species, species_kmers, genome_kmers):
-    completeness = len(interection_of_kmers) / len(core_kmers) * 100
-    assembly_qc = species_kmers.quality_control_rag_for_assembly(len(genome_kmers))
 
-    output_values = [fasta_filename, species,  f"{completeness:.2f}%", f"({len(interection_of_kmers)}/{len(core_kmers)})", str(closest_accession), str(f"{closest_distance:.4f}"), str(len(genome_kmers)),   str(round(species_kmers.genome_kmers_mean)), str(round(species_kmers.genome_kmers_std)), str(assembly_qc)]
-    output_string = "\t".join(output_values)
+    if species == "Species could not be identified, skipping core genome assessment":
+        output_values = [fasta_filename, species,  "NA", "NA", "NA", "NA", "NA", "NA", "NA", "NA"]
+        output_string = "\t".join(output_values)
+    else:
+        completeness = len(interection_of_kmers) / len(core_kmers) * 100
+        assembly_qc = species_kmers.quality_control_rag_for_assembly(len(genome_kmers))
 
-    logging.info(f"Filename: {fasta_filename}")
-    logging.info(f"Closest accession: {closest_accession}")
-    logging.info(f"Closest distance: {closest_distance}")
-    logging.info(f"Number of intersection kmers: {len(interection_of_kmers)}")
-    logging.info(f"Percentage of intersection kmers: {len(interection_of_kmers) / len(core_kmers) * 100}")
-    logging.info(f"Number of core kmers: {len(core_kmers)}")
+        output_values = [fasta_filename, species,  f"{completeness:.2f}%", f"({len(interection_of_kmers)}/{len(core_kmers)})", str(closest_accession), str(f"{closest_distance:.4f}"), str(len(genome_kmers)),   str(round(species_kmers.genome_kmers_mean)), str(round(species_kmers.genome_kmers_std)), str(assembly_qc)]
+        output_string = "\t".join(output_values)
+
+        logging.info(f"Filename: {fasta_filename}")
+        logging.info(f"Closest accession: {closest_accession}")
+        logging.info(f"Closest distance: {closest_distance}")
+        logging.info(f"Number of intersection kmers: {len(interection_of_kmers)}")
+        logging.info(f"Percentage of intersection kmers: {len(interection_of_kmers) / len(core_kmers) * 100}")
+        logging.info(f"Number of core kmers: {len(core_kmers)}")
     return output_string
 
 def construct_consise_output(interection_of_kmers, core_kmers, fasta_filename, species):
+    if species == "Species could not be identified, skipping core genome assessment":
+        return f"{fasta_filename}\t{species}\tNA"
     completeness = len(interection_of_kmers) / len(core_kmers) * 100
     return f"{fasta_filename}\t{species}\t{completeness:.2f}%"
 
@@ -153,30 +161,40 @@ def main():
 
     for fasta_filename in options.fasta_filenames:
         logging.info(f"Processing {fasta_filename}")
-        closest_accession, closest_distance = run_gambit_core_check(options.gambit_directory, fasta_filename, options.cpus)
+        closest_accession, closest_distance, rank = run_gambit_core_check(options.gambit_directory, fasta_filename, options.cpus)
 
-        # create a core just of that species
-        db_queries = DatabaseQueries(database_filename)
-        species = db_queries.get_species_from_genomes_accession_from_db(closest_accession)
-        all_species_genome_accessions = db_queries.get_all_genomes_for_a_species_from_db(species)
+        if rank == 'species' or rank == 'subspecies':
 
-        # check that the species is a key in the dictionary
-        if species not in all_species_genome_accessions:
-            raise Exception(f"Could not find species {species} in database")
-        genome_accessions = all_species_genome_accessions[species]
-        
-        core_kmers = []
-        species_kmers = None
-        with load_signatures(signatures_filename) as src:
-            core_kmers, species_kmers = calculate_core(options.core_proportion, options.max_species_genomes, options.num_genomes_per_species, species, genome_accessions, src)
-        
-        genome_kmers = gambit_database_obj.get_kmers_from_fasta(fasta_filename, options.kmer, options.kmer_prefix, options.cpus)
-        interection_of_kmers = intersection_kmers(core_kmers[0], genome_kmers)
+            # create a core just of that species
+            db_queries = DatabaseQueries(database_filename)
+            species = db_queries.get_species_from_genomes_accession_from_db(closest_accession)
+            all_species_genome_accessions = db_queries.get_all_genomes_for_a_species_from_db(species)
 
-        if options.concise:
-            print(construct_consise_output(interection_of_kmers, core_kmers[0], fasta_filename, species))
+            # check that the species is a key in the dictionary
+            if species not in all_species_genome_accessions:
+                raise Exception(f"Could not find species {species} in database")
+            genome_accessions = all_species_genome_accessions[species]
+            
+            core_kmers = []
+            species_kmers = None
+            with load_signatures(signatures_filename) as src:
+                core_kmers, species_kmers = calculate_core(options.core_proportion, options.max_species_genomes, options.num_genomes_per_species, species, genome_accessions, src)
+            
+            genome_kmers = gambit_database_obj.get_kmers_from_fasta(fasta_filename, options.kmer, options.kmer_prefix, options.cpus)
+            interection_of_kmers = intersection_kmers(core_kmers[0], genome_kmers)
+
+            if options.concise:
+                print(construct_consise_output(interection_of_kmers, core_kmers[0], fasta_filename, species))
+            else:
+                print(construct_extended_output(interection_of_kmers, core_kmers[0], closest_accession, closest_distance, fasta_filename, species, species_kmers, genome_kmers))
+
         else:
-            print(construct_extended_output(interection_of_kmers, core_kmers[0], closest_accession, closest_distance, fasta_filename, species, species_kmers, genome_kmers))
+            logging.info(f"Skipping {fasta_filename} as it is not a species or subspecies call")
+
+            if options.concise:
+                print(construct_consise_output(0, 0, fasta_filename, "Species could not be identified, skipping core genome assessment"))
+            else:
+                print(construct_extended_output(0, 0, 0, 0, fasta_filename, "Species could not be identified, skipping core genome assessment", 0, 0))
 
 if __name__ == "__main__":
     main()

--- a/scripts/gambitcore
+++ b/scripts/gambitcore
@@ -42,6 +42,9 @@ def parse_arguments():
     # Output
     parser.add_argument('--verbose', '-v', action='store_true', help='Turn on verbose output', default=False)
 
+    # Version
+    parser.add_argument('--version', action='version', version='%(prog)s 0.0.2')
+
     return parser.parse_args()
 
 def run_gambit_core_check(gambit_directory, fasta_filename, cpus):

--- a/scripts/gambitcore
+++ b/scripts/gambitcore
@@ -148,6 +148,10 @@ def num_genomes_per_species_threshold(num_genomes_per_species, filtered_src):
 
 def main():
     options = parse_arguments()
+
+    if options.verbose:
+        logging.basicConfig(level=logging.INFO)
+
     gambit_database_obj = GambitDatabase(options.gambit_directory)
     database_filename, signatures_filename = gambit_database_obj.find_gambit_files()
     if database_filename is None or  signatures_filename  is None:
@@ -163,7 +167,8 @@ def main():
         logging.info(f"Processing {fasta_filename}")
         closest_accession, closest_distance, rank = run_gambit_core_check(options.gambit_directory, fasta_filename, options.cpus)
 
-        if rank == 'species' or rank == 'subspecies':
+        # check if a species-level is being made. Options: genus, species and species group
+        if 'species' in rank:
 
             # create a core just of that species
             db_queries = DatabaseQueries(database_filename)
@@ -189,7 +194,7 @@ def main():
                 print(construct_extended_output(interection_of_kmers, core_kmers[0], closest_accession, closest_distance, fasta_filename, species, species_kmers, genome_kmers))
 
         else:
-            logging.info(f"Skipping {fasta_filename} as it is not a species or subspecies call")
+            logging.info(f"Skipping {fasta_filename} as it is not a species-level call")
 
             if options.concise:
                 print(construct_consise_output(0, 0, fasta_filename, "Species could not be identified, skipping core genome assessment"))


### PR DESCRIPTION
This PR alters GAMBITcore functionality to only calculate core-genome score if GAMBIT's call is either Species or Subspecies.

To accomplish this, a few things have been changed:
- GAMBIT's output is now set to `json` instead of `archive` to retrieve the rank of the top species
  - This avoids having to query the database again and many SQL tears
-  A check has been added to GAMBITcore's main function to evaluate what rank the call is
- The construct output functions were adjusted slightly to allow for the failed species call scenario
- The README has been updated slightly